### PR TITLE
Fixing Floating Video Playing Tracker of Hightlight section. 

### DIFF
--- a/src/components/Highlights.jsx
+++ b/src/components/Highlights.jsx
@@ -15,7 +15,7 @@ const Highlights = () => {
       id="highlights"
       className="w-screen overflow-hidden h-full common-padding bg-[#1D1D1F]"
     >
-      <div className="screen-max-width">
+      <div className="screen-max-width mb-48"> 
         <div className="mb-8 w-full md:flex items-end justify-between mt-80">
           <h1
             id="title"

--- a/src/components/VideoCarousel.jsx
+++ b/src/components/VideoCarousel.jsx
@@ -22,6 +22,20 @@ const VideoCarousel = () => {
 
   const [loadedData, setLoadedData] = useState([]);
   const { isEnd, isLastVideo, startPlay, videoId, isPlaying } = video;
+  // pop ups
+  useGSAP(()=>{
+    console.log("here");
+    gsap.from("#playBar",{
+      opacity:0,
+      delay:0,
+      duration:0,
+      scrollTrigger:{
+        trigger:"#slider",
+        toggleActions: "restart none none none",
+        markers:true
+      }
+    })
+  })
 
   useGSAP(() => {
     gsap.to("#slider", {
@@ -150,7 +164,7 @@ const VideoCarousel = () => {
 
   return (
     <>
-      <div className="flex items-center">
+      <div className="flex items-center border-2 border-red-500">
         {hightlightsSlides.map((list, i) => (
           <div key={list.id} id="slider" className="sm:pr-40 pr-20">
             <div className="video-carousel_container">
@@ -196,7 +210,8 @@ const VideoCarousel = () => {
         ))}
       </div>
 
-      <div className="relative flex-center mt-80">
+{/* the play bar */}
+      <div id="playBar" className="fixed hidden bottom-5 left-1 right-1 flex-center mt-10 border-2 overflow-visible border-blue">
         <button className="control-btn">
           <img
             src={isLastVideo ? replayImg : !isPlaying ? playImg : pauseImg}

--- a/src/components/VideoCarousel.jsx
+++ b/src/components/VideoCarousel.jsx
@@ -23,12 +23,14 @@ const VideoCarousel = () => {
   const [loadedData, setLoadedData] = useState([]);
   const { isEnd, isLastVideo, startPlay, videoId, isPlaying } = video;
   // pop ups
+  //remove the ease option if you dont want the bouncing effect
   useGSAP(()=>{
     gsap.from("#playBar",{
       delay:0,
       duration:0.75,
       opacity:0,
       scale:0,
+      ease:"bounce.inOut",
       bottom: "-130px",
       scrollTrigger:{
         trigger:"#slider",

--- a/src/components/VideoCarousel.jsx
+++ b/src/components/VideoCarousel.jsx
@@ -24,15 +24,17 @@ const VideoCarousel = () => {
   const { isEnd, isLastVideo, startPlay, videoId, isPlaying } = video;
   // pop ups
   useGSAP(()=>{
-    console.log("here");
     gsap.from("#playBar",{
-      opacity:0,
       delay:0,
-      duration:0,
+      duration:0.75,
+      opacity:0,
+      scale:0,
+      bottom: "-130px",
       scrollTrigger:{
         trigger:"#slider",
-        toggleActions: "restart none none none",
-        markers:true
+        start:"center bottom",
+        end:"70% 20%",
+        toggleActions:"restart reset resume reset",
       }
     })
   })
@@ -164,7 +166,7 @@ const VideoCarousel = () => {
 
   return (
     <>
-      <div className="flex items-center border-2 border-red-500">
+      <div className="flex items-center">
         {hightlightsSlides.map((list, i) => (
           <div key={list.id} id="slider" className="sm:pr-40 pr-20">
             <div className="video-carousel_container">
@@ -211,7 +213,7 @@ const VideoCarousel = () => {
       </div>
 
 {/* the play bar */}
-      <div id="playBar" className="fixed hidden bottom-5 left-1 right-1 flex-center mt-10 border-2 overflow-visible border-blue">
+      <div id="playBar" className="fixed bottom-10 left-1 right-1 z-10 flex-center mt-10  overflow-visible ">
         <button className="control-btn">
           <img
             src={isLastVideo ? replayImg : !isPlaying ? playImg : pauseImg}


### PR DESCRIPTION
## [Issue resolved](https://github.com/NiranjanKumar001/iPhone16Pro/issues/5)
# Added Feature
Now the video player is completely a **floating bar**
![image](https://github.com/user-attachments/assets/4a7a33d1-b004-4035-b24d-e4d622d7ff12)
### other features
1. it fades in with a bouncing effect
2. it fades out when the highlight section is passed on

Just like it is in the reference website

## Brief changes
1. The video playing tracker is set to fixed position with usual opacity 0% and out of the window frame
2. whenever we approach the highlight section it pops in , ie making the opacity to 100% and fixing the player in the bottom position.
3. And again sets to default while moving out.
## customization
most of the customization are done in a single hook with well defined commenting so the floating bar is open to any new customization.

working demo :-> https://drive.google.com/file/d/17IF0cArmcPMdOyTa7frUEjaX7o4aKm1x/view?usp=sharing

