### PR TITLE
Buy button styling now replicates the original website

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -119,7 +119,7 @@ const HeroWithNavbar = () => {
           >
             <a
               href="#highlights"
-              className="btn bg-white text-black rounded-full text-lg font-medium mb-4 hover:bg-opacity-90 transition-all"
+              className="btn bg-white text-white rounded-full text-md font-thin mb-4 "
             >
               Buy
             </a>

--- a/src/index.css
+++ b/src/index.css
@@ -39,8 +39,7 @@ canvas {
   }
 
   .btn {
-    @apply px-5 py-2 rounded-3xl bg-blue my-5 hover:bg-transparent border border-transparent hover:border hover:text-blue hover:border-blue
-  }
+    @apply px-4 py-2 rounded-3xl bg-blue my-5 }
 
   .color-container {
     @apply flex items-center justify-center px-4 py-4 rounded-full bg-gray-300 backdrop-blur


### PR DESCRIPTION
The button style now is similar to the original website.
new button -->
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/f4835054-71ce-4ae3-af31-b32aa602e18f">
